### PR TITLE
Progress indicator for when a local model / Eng is downloading

### DIFF
--- a/sidebar/sidebar.css
+++ b/sidebar/sidebar.css
@@ -50,3 +50,31 @@ moz-extension-hub {
     color: var(--color-text);
   }
 }
+
+moz-engine-download-progress {
+  --color-bg: #094f22dc;
+  --color-fg: #ffffff;
+  position: fixed;
+  top: 0;
+  width: 100%;
+
+  .progress-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--color-fg);
+    background-color: var(--color-bg);
+    padding: 24px;
+  }
+
+  .progress-close-button {
+    position: absolute;
+    top: 4px;
+    right: 10px;
+    background: none;
+    border: none;
+    color: var(--color-fg);
+    font-size: 16px;
+    cursor: pointer;
+  }
+}

--- a/src/components/ExtensionHub.ts
+++ b/src/components/ExtensionHub.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit'
 import { LocalStorageKeys } from '../../const'
+import './MozEngineDownloadProgress'
 
 type FeatureOption = {
   value: 'page_qa' | 'page_summarization' | 'tab_summarization' | 'chat'
@@ -73,6 +74,8 @@ class MozExtensionHub extends LitElement {
     const selected = FEATURE_OPTIONS.find((opt) => opt.value === this.feature)
     return html`
       <div class="wrapper">
+        <moz-engine-download-progress></moz-engine-download-progress>
+
         <div class="header">
           <select class="select" @change="${this.handleSelectChange}">
             ${FEATURE_OPTIONS.map(

--- a/src/components/ExtensionHub.ts
+++ b/src/components/ExtensionHub.ts
@@ -75,7 +75,6 @@ class MozExtensionHub extends LitElement {
     return html`
       <div class="wrapper">
         <moz-engine-download-progress></moz-engine-download-progress>
-
         <div class="header">
           <select class="select" @change="${this.handleSelectChange}">
             ${FEATURE_OPTIONS.map(

--- a/src/components/MozEngineDownloadProgress.ts
+++ b/src/components/MozEngineDownloadProgress.ts
@@ -30,13 +30,14 @@ export class MozEngineDownloadProgress extends LitElement {
   }
 
   handleIncomingMessage = async (message: any) => {
-    if (message.type === 'mlEngine_download_progress') {
-      this.isVisible = this.closedByUser ? false : true
-      this.progress = message.progress
-      if (this.progress >= 99) {
-        this.isVisible = false
-        this.progress = 0
-      }
+    if (message.type !== 'mlEngine_download_progress') return
+
+    this.isVisible = this.closedByUser ? false : true
+    this.progress = message.progress
+    // Adding a buffer to 100 with 99 because it does not always reach exactly 100%
+    if (this.progress >= 99) {
+      this.isVisible = false
+      this.progress = 0
     }
   }
 

--- a/src/components/MozEngineDownloadProgress.ts
+++ b/src/components/MozEngineDownloadProgress.ts
@@ -1,0 +1,62 @@
+import { LitElement, html } from 'lit'
+
+export class MozEngineDownloadProgress extends LitElement {
+  isVisible: boolean = false
+  progress: number = 0
+  closedByUser: boolean = false
+
+  static properties = {
+    isVisible: { type: Boolean },
+    progress: { type: Number },
+    closedByUser: { type: Boolean },
+  }
+
+  constructor() {
+    super()
+  }
+
+  createRenderRoot() {
+    return this
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    browser.runtime.onMessage.addListener(this.handleIncomingMessage)
+  }
+
+  disconnectedCallback() {
+    browser.runtime.onMessage.removeListener(this.handleIncomingMessage)
+    super.disconnectedCallback()
+  }
+
+  handleIncomingMessage = async (message: any) => {
+    if (message.type === 'mlEngine_download_progress') {
+      this.isVisible = this.closedByUser ? false : true
+      this.progress = message.progress
+      if (this.progress >= 99) {
+        this.isVisible = false
+        this.progress = 0
+      }
+    }
+  }
+
+  render() {
+    if (!this.isVisible) {
+      return html``
+    }
+
+    return html`
+      <button
+        class="progress-close-button"
+        @click="${() => (this.closedByUser = true)}"
+      >
+        <span class="fa fa-close"></span>
+      </button>
+      <div class="progress-container">
+        ML Engine Download Progress: ${Math.floor(this.progress)}%
+      </div>
+    `
+  }
+}
+
+customElements.define('moz-engine-download-progress', MozEngineDownloadProgress)

--- a/src/services/mlEngine.ts
+++ b/src/services/mlEngine.ts
@@ -38,8 +38,15 @@ const ensureEngineIsReady = async () => {
 
 export const getMlEngineAIResponse = async (prompt: string) => {
   try {
-    await ensureEngineIsReady()
     const trial = (browser as unknown as mlBrowserT).trial
+    trial?.ml.onProgress.addListener((data) => {
+      const { progress } = data
+      browser.runtime.sendMessage({
+        type: 'mlEngine_download_progress',
+        progress,
+      })
+    })
+    await ensureEngineIsReady()
     const chatInput = [
       {
         role: 'system',

--- a/types.ts
+++ b/types.ts
@@ -4,6 +4,9 @@ export type mlBrowserT = {
       createEngine: (options: any) => Promise<any>
       runEngine: (options: any) => Promise<any>
       deleteCachedModels: () => Promise<void>
+      onProgress: {
+        addListener: (callback: (data: any) => void) => void
+      }
     }
   }
   tabs: {


### PR DESCRIPTION
In the effort to building out the local model experience we needed to add a progress indicator for when the model is downloading so not to confuse downloading time with inference time. This patch just adds the UI to the extension hub root from signals in the mlEngine service. 