### PR TITLE
add experimental tabs api to get smart tab grouping and other tabs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,22 @@
   "manifest_version": 2,
   "name": "Extension Hub",
   "version": "1.0.0",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "extensionHub@mozilla.org"
+    }
+  },
   "description": "An extension hub to prototype and test various ideas.",
+  "experiment_apis": {
+    "extensionHub": {
+      "parent": {
+        "paths": [["extensionHub"]],
+        "scopes": ["addon_parent"],
+        "script": "dist/api.js"
+      },
+      "schema": "schema.json"
+    }
+  },
   "optional_permissions": ["trialML"],
   "permissions": ["<all_urls>", "menus", "scripting", "storage","activeTab","history","tabs","tabGroups"],
   "icons": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack",
-    "start": "web-ext run --firefox=nightly",
+    "start": "web-ext run --firefox=nightly --pref=extensions.experiments.enabled=true",
     "watch": "webpack --watch"
   },
   "keywords": [],

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,13 @@
+[
+  {
+    "functions": [
+      {
+        "async": true,
+        "name": "getTabs",
+        "parameters": [],
+        "type": "function"
+      }
+    ],
+    "namespace": "extensionHub"
+  }
+]

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,71 @@
+import type { mlBrowserT, TabsCollectionT } from '../types'
+
+declare const ChromeUtils: any
+declare const ExtensionAPI: any
+declare const Services: any
+interface BrowserTab {
+  group?: { tabs: BrowserTab[] }
+  label: string
+  lastAccessed: number
+  linkedBrowser: {
+    currentURI: {
+      spec: string
+    }
+  }
+}
+
+const lazy: { SmartTabGroupingManager?: any } = {}
+ChromeUtils.defineESModuleGetters(lazy, {
+  SmartTabGroupingManager:
+    'moz-src:///browser/components/tabbrowser/SmartTabGrouping.sys.mjs',
+})
+
+export default class extends ExtensionAPI {
+  getAPI(context: any): { extensionHub: mlBrowserT['extensionHub'] } {
+    return {
+      extensionHub: {
+        async getTabs(): Promise<TabsCollectionT> {
+          const {
+            selectedTab,
+            tabs,
+          }: { selectedTab: BrowserTab; tabs: BrowserTab[] } =
+            Services.wm.getMostRecentBrowserWindow().gBrowser
+
+          const current: { tabs: BrowserTab[] } = selectedTab.group ?? {
+            tabs: [selectedTab],
+          }
+          const recent: BrowserTab[] = [...tabs]
+            .sort(
+              (a: BrowserTab, b: BrowserTab) => b.lastAccessed - a.lastAccessed,
+            )
+            .slice(0, 5)
+
+          const manager = new lazy.SmartTabGroupingManager()
+          const smart: BrowserTab[] = await manager.smartTabGroupingForGroup(
+            current,
+            tabs,
+          )
+
+          const tabCollections = {
+            current: current.tabs,
+            recent,
+            smart,
+            smarter: [...current.tabs, ...smart],
+            start: tabs.slice(0, 5),
+            tail: tabs.slice(-5),
+          }
+
+          return Object.fromEntries(
+            Object.entries(tabCollections).map(([key, val]) => [
+              key,
+              val.map((tab: BrowserTab) => ({
+                title: tab.label,
+                url: tab.linkedBrowser.currentURI.spec,
+              })),
+            ]),
+          ) as TabsCollectionT
+        },
+      },
+    }
+  }
+}

--- a/src/components/ExtensionHub.ts
+++ b/src/components/ExtensionHub.ts
@@ -3,7 +3,12 @@ import { LocalStorageKeys } from '../../const'
 import './MozEngineDownloadProgress'
 
 type FeatureOption = {
-  value: 'page_qa' | 'page_summarization' | 'tab_summarization' | 'chat'
+  value:
+    | 'chat'
+    | 'page_qa'
+    | 'page_summarization'
+    | 'tab_summarization'
+    | 'tabs_debug'
   label: string
   component: () => unknown
 }
@@ -29,6 +34,11 @@ const FEATURE_OPTIONS: FeatureOption[] = [
     value: 'chat',
     label: 'Chat',
     component: () => html`<moz-chat></moz-chat>`,
+  },
+  {
+    value: 'tabs_debug',
+    label: 'Tabs Debug',
+    component: () => html`<moz-tabs-debug></moz-tabs-debug>`,
   },
 ]
 

--- a/src/features/MozTabsDebug.ts
+++ b/src/features/MozTabsDebug.ts
@@ -1,0 +1,61 @@
+import { LitElement, html } from 'lit'
+import { mlBrowserT, TabsCollectionT, TabsT } from '../../types'
+
+class MozTabsDebug extends LitElement {
+  tabs: TabsCollectionT | null = null
+
+  static properties = {
+    tabs: { type: Object },
+  }
+
+  constructor() {
+    super()
+    this.loadTabs()
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    browser.tabs.onActivated.addListener(this.loadTabs)
+    browser.tabs.onUpdated.addListener(this.loadTabs)
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback()
+    browser.tabs.onActivated.removeListener(this.loadTabs)
+    browser.tabs.onUpdated.removeListener(this.loadTabs)
+  }
+
+  loadTabs = async () => {
+    this.tabs = await (browser as unknown as mlBrowserT).extensionHub.getTabs()
+  }
+
+  createRenderRoot() {
+    return this
+  }
+
+  render() {
+    return html`
+      <div class="wrapper">
+        <div class="card">
+          <h3>Tabs</h3>
+          <div class="fields">
+            ${this.tabs
+              ? Object.entries(this.tabs).map(
+                  ([key, tabArray]) => html`
+                    <h4>${key}</h4>
+                    <ul>
+                      ${(tabArray as TabsT).map(
+                        (tab) => html`<li>${tab.title}</li>`,
+                      )}
+                    </ul>
+                  `,
+                )
+              : html`<p>Loading...</p>`}
+          </div>
+        </div>
+      </div>
+    `
+  }
+}
+
+export default MozTabsDebug

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -3,9 +3,11 @@ import MozPageSummarization from './features/page-summarization/MozPageSummariza
 import MozTabs from './features/MozTabs'
 import ExtensionHub from './components/ExtensionHub'
 import MozChat from './features/chat/MozChat'
+import MozTabsDebug from './features/MozTabsDebug'
 
 customElements.define('moz-question-answer', MozQuestionAnswer)
 customElements.define('moz-extension-hub', ExtensionHub)
 customElements.define('moz-page-summarization', MozPageSummarization)
 customElements.define('moz-tabs', MozTabs)
 customElements.define('moz-chat', MozChat)
+customElements.define('moz-tabs-debug', MozTabsDebug)

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,7 @@
 export type mlBrowserT = {
+  extensionHub: {
+    getTabs: () => Promise<TabsCollectionT>
+  }
   trial?: {
     ml: {
       createEngine: (options: any) => Promise<any>
@@ -60,4 +63,18 @@ export type PageContentT = {
   textContent: string
   siteName: string
   url?: string
+}
+
+export type TabsT = Array<{
+  title: string
+  url: string
+}>
+
+export type TabsCollectionT = {
+  current: TabsT
+  recent: TabsT
+  smart: TabsT
+  smarter: TabsT
+  start: TabsT
+  tail: TabsT
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,14 @@ const Dotenv = require('dotenv-webpack')
 module.exports = {
   mode: 'development',
   entry: {
+    api: {
+      import: './src/api.ts',
+      library: {
+        export: 'default',
+        name: 'extensionHub',
+        type: 'this',
+      },
+    },
     content: './src/content.ts',
     sidebar: './src/sidebar.ts',
     background: './src/background.ts',


### PR DESCRIPTION
webpack api.ts to assign window.extensionHub expected by extension loader. include tab debug view as an example to view tabs