### PR TITLE
By default make start reuse a profile to avoid onboarding each time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ web-ext-artifacts
 .env
 .DS_Store
 *.txt
+profile

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack",
     "release": "node release.js",
-    "start": "web-ext run --firefox=nightly --pref=extensions.experiments.enabled=true",
+    "start": "web-ext run --firefox=nightly --pref=extensions.experiments.enabled=true --pref=browser.startup.page=3 --profile-create-if-missing --keep-profile-changes --firefox-profile=./profile",
+    "start:fresh": "web-ext run --firefox=nightly --pref=extensions.experiments.enabled=true",
     "watch": "webpack --watch",
     "xpi": "webpack && web-ext build --artifacts-dir . --filename extension-hub.xpi --overwrite-dest"
   },


### PR DESCRIPTION
Maybe I'm missing something but local development has a papercut with a new profile each time which makes it harder to persist extension settings / tabs / history etc for testing.

This change renames the current behavior to `start:fresh` and creates a reused profile in the working directory, plus sets a pref to restore tabs at startup.